### PR TITLE
Update README to specify beta version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Redux bindings for React Router.
 - Works with time travel feature of Redux Devtools!
 
 ```js
-npm install --save redux-router
+npm install --save redux-router@1.0.0-beta3
 ```
 
 ## Why


### PR DESCRIPTION
If you run the `npm install` command without specifying a version,
you get 0.1.0, which appears non-functional (see: https://gist.github.com/nickpresta/513ccf6be4f40db60b2a)