### PR TITLE
The latest routerState should be stored in store subscribe

### DIFF
--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -34,10 +34,17 @@ describe('reduxRouter()', () => {
       routes
     })(createStore)(reducer);
 
+    const historySpy = sinon.spy();
+    history.listen(s => historySpy());
+    
+    expect(historySpy.callCount).to.equal(1);
+
     history.pushState(null, '/parent');
     expect(store.getState().router.location.pathname).to.equal('/parent');
+    expect(historySpy.callCount).to.equal(2);
 
     history.pushState(null, '/parent/child/123?key=value');
+    expect(historySpy.callCount).to.equal(3);
     expect(store.getState().router.location.pathname)
       .to.equal('/parent/child/123');
     expect(store.getState().router.location.query).to.eql({ key: 'value' });
@@ -71,9 +78,13 @@ describe('reduxRouter()', () => {
     }
 
     const history = createHistory();
+    const historySpy = sinon.spy();
 
     let historyState;
-    history.listen(s => historyState = s);
+    history.listen(s => {
+      historySpy();
+      historyState = s;
+    });
 
     const store = reduxReactRouter({
       history,
@@ -81,6 +92,7 @@ describe('reduxRouter()', () => {
     })(createStore)(reducer);
 
     expect(reducerSpy.callCount).to.equal(2);
+    expect(historySpy.callCount).to.equal(1);
 
     store.dispatch({
       type: EXTERNAL_STATE_CHANGE,
@@ -88,6 +100,7 @@ describe('reduxRouter()', () => {
     });
 
     expect(reducerSpy.callCount).to.equal(4);
+    expect(historySpy.callCount).to.equal(2);
     expect(historyState.pathname).to.equal('/parent/child/123');
     expect(historyState.search).to.equal('?key=value');
   });

--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -5,6 +5,7 @@ import {
   replaceState,
   isActive
 } from '../';
+import { REPLACE_ROUTES } from '../constants';
 
 import { createStore, combineReducers } from 'redux';
 import React from 'react';
@@ -139,6 +140,35 @@ describe('reduxRouter()', () => {
     store.dispatch({ type: APPEND_STRING, string: 'Uni' });
     store.dispatch({ type: APPEND_STRING, string: 'directional' });
     expect(store.getState().string).to.equal('Unidirectional');
+  });
+
+  it('stores the latest state in routerState', () => {
+    const reducer = combineReducers({
+      router: routerStateReducer
+    });
+
+    const history = createHistory();
+
+    const store = reduxReactRouter({
+      history,
+      routes
+    })(createStore)(reducer);
+
+    let historyState;
+    history.listen(s => {
+      historyState = s;
+    });
+
+    history.pushState(null, '/parent');
+
+    store.dispatch({
+      type: REPLACE_ROUTES
+    });
+
+    historyState = null;
+
+    store.dispatch({ type: 'RANDOM_ACTION' });
+    expect(historyState).to.equal(null);
   });
 
   describe('getRoutes()', () => {

--- a/src/client.js
+++ b/src/client.js
@@ -11,6 +11,7 @@ function historySynchronization(next) {
     const store = next(options)(createStore)(reducer, initialState);
     const { history } = store;
 
+    let prevRouterState;
     let routerState;
 
     history.listen((error, nextRouterState) => {
@@ -20,6 +21,7 @@ function historySynchronization(next) {
       }
 
       if (!routerStateEquals(routerState, nextRouterState)) {
+        prevRouterState = routerState;
         routerState = nextRouterState;
         store.dispatch(routerDidChange(nextRouterState));
       }
@@ -27,13 +29,13 @@ function historySynchronization(next) {
 
     store.subscribe(() => {
       const nextRouterState = routerStateSelector(store.getState());
-      const currentRouterState = routerState;
-      routerState = nextRouterState;
 
       if (
         nextRouterState &&
-        !routerStateEquals(currentRouterState, nextRouterState)
+        prevRouterState !== nextRouterState &&
+        !routerStateEquals(routerState, nextRouterState)
       ) {
+        routerState = nextRouterState;
         const { state, pathname, query } = nextRouterState.location;
         history.replaceState(state, pathname, query);
       }

--- a/src/client.js
+++ b/src/client.js
@@ -28,16 +28,16 @@ function historySynchronization(next) {
 
     store.subscribe(() => {
       const nextRouterState = routerStateSelector(store.getState());
+      const currentRouterState = routerState;
+      routerState = nextRouterState;
 
       if (
         nextRouterState &&
-        !routerStateEquals(routerState, nextRouterState)
+        !routerStateEquals(currentRouterState, nextRouterState)
       ) {
         const { state, pathname, query } = nextRouterState.location;
         history.replaceState(state, pathname, query);
       }
-
-      routerState = nextRouterState;
     });
 
     return store;

--- a/src/client.js
+++ b/src/client.js
@@ -19,9 +19,8 @@ function historySynchronization(next) {
         return;
       }
 
-      const prevRouterState = routerStateSelector(store.getState());
-
-      if (!routerStateEquals(prevRouterState, nextRouterState)) {
+      if (!routerStateEquals(routerState, nextRouterState)) {
+        routerState = nextRouterState;
         store.dispatch(routerDidChange(nextRouterState));
       }
     });


### PR DESCRIPTION
Currently, `routerState` in client.js doesn't store the latest router state because `history.replaceState` is not async. What ends up happening is that `DOES_NEED_REFRESH` ends up getting stored until any given next action updates the store and then replaceState is triggered yet again. This is obviously incorrect, as `DOES_NEED_REFRESH` already did its job the first time around.

Due to the lack of access to `routerState`, the test I created is pretty round-about but basically it checks for whether triggering a random action after `REPLACE_ROUTES` causes `history.listen` to trigger. (It should not.)