### PR TITLE
createLocation can only be called through an instance of history

### DIFF
--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -130,13 +130,14 @@ describe('<ReduxRouter>', () => {
       });
 
       const store = server.reduxReactRouter({ routes })(createStore)(reducer);
-      store.dispatch(server.match('/parent/child/850', () => {
+      store.dispatch(server.match('/parent/child/850?key=value', (err, redirectLocation, routerState) => {
         const output = renderToString(
           <Provider store={store}>
             <ReduxRouter />
           </Provider>
         );
         expect(output).to.match(/Pathname: \/parent\/child\/850/);
+        expect(routerState.location.query).to.eql({ key: 'value' });
       }));
     });
 

--- a/src/matchMiddleware.js
+++ b/src/matchMiddleware.js
@@ -1,4 +1,3 @@
-import createLocation from 'history/lib/createLocation';
 import { routerDidChange } from './actionCreators';
 import { MATCH } from './constants';
 
@@ -6,8 +5,7 @@ export default function matchMiddleware(match) {
   return ({ dispatch }) => next => action => {
     if (action.type === MATCH) {
       const { url, callback } = action.payload;
-      const location = createLocation(url);
-      match(location, (error, redirectLocation, routerState) => {
+      match(url, (error, redirectLocation, routerState) => {
         if (!error && !redirectLocation) {
           dispatch(routerDidChange(routerState));
         }

--- a/src/server.js
+++ b/src/server.js
@@ -25,7 +25,11 @@ function matching(next) {
   return options => createStore => (reducer, initialState) => {
     const store = compose(
       applyMiddleware(
-        matchMiddleware((...args) => store.history.match(...args))
+        matchMiddleware((url, callback) => {
+          const location = store.history.createLocation(url);
+
+          store.history.match(location, callback);
+        })
       ),
       next({
         ...options,


### PR DESCRIPTION
I didn't see a clean way of doing `history.createLocation` within the matchMiddleware so src/server.js is now responsible for createLocation, as well as match. Addresses #102.

Let me know if you want me to make any changes to this.