### PR TITLE
Handle 404s gracefully on the server

### DIFF
--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -166,6 +166,19 @@ describe('<ReduxRouter>', () => {
         expect(redirectLocation.pathname).to.equal('/parent/child/850');
       }));
     });
+
+    it('handles 404s gracefully', () => {
+      const reducer = combineReducers({
+        router: routerStateReducer
+      });
+
+      const store = server.reduxReactRouter({ routes })(createStore)(reducer);
+      store.dispatch(server.match('/parent', () => {
+        store.dispatch(server.match('/404', () => {
+          expect(store.getState().router).to.not.be.undefined;
+        }));
+      }));
+    });
   });
 
   describe('dynamic route switching', () => {

--- a/src/matchMiddleware.js
+++ b/src/matchMiddleware.js
@@ -8,7 +8,7 @@ export default function matchMiddleware(match) {
       const { url, callback } = action.payload;
       const location = createLocation(url);
       match(location, (error, redirectLocation, routerState) => {
-        if (!error && !redirectLocation) {
+        if (!error && !redirectLocation && routerState) {
           dispatch(routerDidChange(routerState));
         }
         callback(error, redirectLocation, routerState);


### PR DESCRIPTION
`react-router` will return an undefined routerState (but no error or redirect) when a path match isn't found. `redux-router` doesn't currently check for routerState actually being set before dispatching `routerDidChange`. This results in setting the reducer to undefined and redux throwing an error.

I've included a fix and a test case for it. Addresses #115.