### PR TITLE
Export "push" and "replace" handy methods of history API

### DIFF
--- a/src/actionCreators.js
+++ b/src/actionCreators.js
@@ -42,7 +42,9 @@ export function historyAPI(method) {
 }
 
 export const pushState = historyAPI('pushState');
+export const push = historyAPI('push');
 export const replaceState = historyAPI('replaceState');
+export const replace = historyAPI('replace');
 export const setState = historyAPI('setState');
 export const go = historyAPI('go');
 export const goBack = historyAPI('goBack');


### PR DESCRIPTION
There are also [two handy methods](https://github.com/rackt/history/blob/master/docs/GettingStarted.md#navigation) of history API that allow not to specify state object during transitions:

* `push(path[, state])`
* `replace(path[, state])`

