### PR TITLE
Fix: Don't throw when match is used with an unknown location

### DIFF
--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -141,6 +141,16 @@ describe('<ReduxRouter>', () => {
       }));
     });
 
+    it('should handle non matched routes', () => {
+      const reducer = combineReducers({
+        router: routerStateReducer
+      });
+
+      const store = server.reduxReactRouter({ routes })(createStore)(reducer);
+      expect(() => store.dispatch(server.match('/404', () => {})))
+        .to.not.throw();
+    });
+
     it('throws if routes are not passed to store enhancer', () => {
       const reducer = combineReducers({
         router: routerStateReducer

--- a/src/matchMiddleware.js
+++ b/src/matchMiddleware.js
@@ -6,7 +6,7 @@ export default function matchMiddleware(match) {
     if (action.type === MATCH) {
       const { url, callback } = action.payload;
       match(url, (error, redirectLocation, routerState) => {
-        if (!error && !redirectLocation) {
+        if (!error && !redirectLocation && routerState) {
           dispatch(routerDidChange(routerState));
         }
         callback(error, redirectLocation, routerState);


### PR DESCRIPTION
The following currently throws but it should be possible to use match with unknown urls

```js
const routes = (
  <Route path="/" component={App}>
    <Route path="child/" component={Child} />
  </Route>
);

store.dispatch(server.match('/404', () => {}))
```