### PR TITLE
Using react-router 1.0 instead of rc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-addons-test-utils": "^0.14.1",
     "react-dom": "^0.14.1",
     "react-redux": "^4.0.0",
-    "react-router": "1.0.0-rc3",
+    "react-router": "1.0.0",
     "redux": "3.x",
     "redux-devtools": "^2.1.0",
     "rimraf": "^2.4.3",


### PR DESCRIPTION
react-router 1.0 has been released, so we should upgrade it.