### PR TITLE
Update reduxReactRouter to accept history object

### DIFF
--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -11,6 +11,7 @@ import { createStore, combineReducers, compose, applyMiddleware } from 'redux';
 import React from 'react';
 import { Route } from 'react-router';
 import createHistory from 'history/lib/createMemoryHistory';
+import useBaseName from 'history/lib/useBaseName';
 import sinon from 'sinon';
 
 const routes = (
@@ -212,6 +213,31 @@ describe('reduxRouter()', () => {
       expect(historySpy.callCount).to.equal(2);
       done();
     }, 0);
+  });
+
+  it('accepts history object when using basename', () => {
+    const reducer = combineReducers({
+      router: routerStateReducer
+    });
+
+    const history = useBaseName(createHistory)({
+      basename: '/grandparent'
+    });
+
+    const store = reduxReactRouter({
+      history,
+      routes
+    })(createStore)(reducer);
+
+    history.pushState(null, '/parent');
+    expect(store.getState().router.location.pathname).to.eql('/parent');
+
+    history.pushState(null, '/parent/child/123?key=value');
+    expect(store.getState().router.location.pathname)
+      .to.eql('/parent/child/123');
+    expect(store.getState().router.location.basename).to.eql('/grandparent');
+    expect(store.getState().router.location.query).to.eql({ key: 'value' });
+    expect(store.getState().router.params).to.eql({ id: '123' });
   });
 
   describe('getRoutes()', () => {

--- a/src/reduxReactRouter.js
+++ b/src/reduxReactRouter.js
@@ -11,7 +11,15 @@ export default function reduxReactRouter({
   routerStateSelector
 }) {
   return createStore => (reducer, initialState) => {
-    const history = useRoutes(createHistory)({
+
+    let baseCreateHistory;
+    if (typeof createHistory === 'function') {
+      baseCreateHistory = createHistory;
+    } else if (createHistory) {
+      baseCreateHistory = () => createHistory;
+    }
+
+    const history = useRoutes(baseCreateHistory)({
       routes,
       parseQueryString,
       stringifyQuery


### PR DESCRIPTION
When using `history` basename function it returns an object. Before this it would only accept a function that returns an object. This update gives users the ability to use other helpers provided by history.

Also update to the tests to account for this new behavior. Most of the tests were kept in this describe block to ensure all other routes stayed the same and that history properly uses the basename for determining root.

One other piece I would like to note is that similar logic also lives in useDefaults. I considered creating an abstraction for both of these instances, but rather not create the wrong one and have to create edge cases for both down the line.

This would fix issue #158