### PR TITLE
Allow to replace RoutingContext

### DIFF
--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { RoutingContext } from 'react-router';
+import { RoutingContext as DefaultRoutingContext } from 'react-router';
 import routerStateEquals from './routerStateEquals';
 import { ROUTER_STATE_SELECTOR } from './constants';
 import { replaceRoutes } from './actionCreators';
@@ -84,6 +84,8 @@ class ReduxRouter extends Component {
 )
 class ReduxRouterContext extends Component {
   render() {
+    const RoutingContext = this.props.RoutingContext || DefaultRoutingContext;
+
     return <RoutingContext {...this.props} />;
   }
 }


### PR DESCRIPTION
I want to use `redux-router` with `react-router-relay`.
`react-router-relay` provides [`RelayRoutingContext`](https://github.com/relay-tools/react-router-relay/blob/master/src/RelayRoutingContext.js) that should replace default `RoutingContext` from `react-router`.
Default router from `react-router` [supports](https://github.com/rackt/react-router/blob/master/modules/Router.js#L88) this feature and I want to add this feature to `redux-router`.