### PR TITLE
Create new action type INIT_ROUTES for initial route loading

### DIFF
--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { RoutingContext as DefaultRoutingContext } from 'react-router';
 import routerStateEquals from './routerStateEquals';
 import { ROUTER_STATE_SELECTOR } from './constants';
-import { replaceRoutes } from './actionCreators';
+import { initRoutes, replaceRoutes } from './actionCreators';
 
 function memoizeRouterStateSelector(selector) {
   let previousRouterState = null;
@@ -33,7 +33,7 @@ class ReduxRouter extends Component {
 
   constructor(props, context) {
     super(props, context);
-    this.receiveRoutes(getRoutesFromProps(props));
+    context.store.dispatch(initRoutes(getRoutesFromProps(props)));
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -19,6 +19,7 @@ import { createStore, combineReducers } from 'redux';
 import createHistory from 'history/lib/createMemoryHistory';
 import { Link, Route } from 'react-router';
 import jsdom from 'mocha-jsdom';
+import sinon from 'sinon';
 
 @connect(state => state.router)
 class App extends Component {
@@ -107,6 +108,32 @@ describe('<ReduxRouter>', () => {
     expect(child.props.location.pathname).to.equal('/parent/child/123');
     expect(child.props.location.query).to.eql({ key: 'value' });
     expect(child.props.params).to.eql({ id: '123' });
+  });
+
+  it('only renders once on initial load', () => {
+    const reducer = combineReducers({
+      router: routerStateReducer
+    });
+
+    const history = createHistory();
+    const store = reduxReactRouter({
+      history
+    })(createStore)(reducer);
+
+    history.pushState(null, '/parent/child/123?key=value');
+
+    const historySpy = sinon.spy();
+    history.listen(() => historySpy());
+
+    renderIntoDocument(
+      <Provider store={store}>
+        <ReduxRouter>
+          {routes}
+        </ReduxRouter>
+      </Provider>
+    );
+
+    expect(historySpy.callCount).to.equal(1);
   });
 
   // <Link> does stuff inside `onClick` that makes it difficult to test.

--- a/src/actionCreators.js
+++ b/src/actionCreators.js
@@ -1,4 +1,4 @@
-import { ROUTER_DID_CHANGE, REPLACE_ROUTES, HISTORY_API } from './constants';
+import { ROUTER_DID_CHANGE, INIT_ROUTES, REPLACE_ROUTES, HISTORY_API } from './constants';
 
 /**
  * Action creator for signaling that the router has changed.
@@ -10,6 +10,18 @@ export function routerDidChange(state) {
   return {
     type: ROUTER_DID_CHANGE,
     payload: state
+  };
+}
+
+/**
+ * Action creator that initiates route config
+ * @private
+ * @param {Array<Route>|ReactElement} routes - New routes
+ */
+export function initRoutes(routes) {
+  return {
+    type: INIT_ROUTES,
+    payload: routes
   };
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ export const ROUTER_DID_CHANGE = '@@reduxReactRouter/routerDidChange';
 
 export const HISTORY_API = '@@reduxReactRouter/historyAPI';
 export const MATCH = '@@reduxReactRouter/match';
+export const INIT_ROUTES = '@@reduxReactRouter/initRoutes';
 export const REPLACE_ROUTES = '@@reduxReactRouter/replaceRoutes';
 
 export const ROUTER_STATE_SELECTOR = '@@reduxReactRouter/routerStateSelector';

--- a/src/replaceRoutesMiddleware.js
+++ b/src/replaceRoutesMiddleware.js
@@ -1,9 +1,10 @@
-import { REPLACE_ROUTES } from './constants';
+import { INIT_ROUTES, REPLACE_ROUTES } from './constants';
 
 export default function replaceRoutesMiddleware(replaceRoutes) {
   return () => next => action => {
-    if (action.type === REPLACE_ROUTES) {
-      replaceRoutes(action.payload);
+    const isInitRoutes = action.type === INIT_ROUTES;
+    if (isInitRoutes || action.type === REPLACE_ROUTES) {
+      replaceRoutes(action.payload, isInitRoutes);
     }
     return next(action);
   };

--- a/src/routeReplacement.js
+++ b/src/routeReplacement.js
@@ -16,11 +16,11 @@ export default function routeReplacement(next) {
     let areChildRoutesResolved = false;
     const childRoutesCallbacks = [];
 
-    function replaceRoutes(r) {
+    function replaceRoutes(r, isInit) {
       childRoutes = createRoutes(r);
 
       const routerState = routerStateSelector(store.getState());
-      if (routerState) {
+      if (routerState && !isInit) {
         const { state, pathname, query } = routerState.location;
         store.history.replaceState(state, pathname, query);
       }


### PR DESCRIPTION
This should finally fix IE9 (#125) and all the extraneous replaceState on initial load. See #107 for more info.

@Scarysize let me know if you need me to clear anything up. There's a test there to confirm that we don't trigger replaceState more than necessary.

I ended up creating a new action because modifying REPLACE_ROUTES to handle both cases seemed like it would be way too brittle and heavy-handed.