### PR TITLE
Remove warnings on initial render when using async/dynamic routes

### DIFF
--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -84,9 +84,9 @@ class ReduxRouter extends Component {
 )
 class ReduxRouterContext extends Component {
   render() {
-    let {location} = this.props;
+    const {location} = this.props;
 
-    if(location == null)
+    if(location === null)
       return null; //Async matching
 
     const RoutingContext = this.props.RoutingContext || DefaultRoutingContext;

--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -84,6 +84,11 @@ class ReduxRouter extends Component {
 )
 class ReduxRouterContext extends Component {
   render() {
+    let {location} = this.props;
+
+    if(location == null)
+      return null; //Async matching
+
     const RoutingContext = this.props.RoutingContext || DefaultRoutingContext;
 
     return <RoutingContext {...this.props} />;


### PR DESCRIPTION
When using dynamic/async routing (https://github.com/rackt/react-router/blob/master/docs/guides/advanced/DynamicRouting.md), warnings are issued on first render :
<img width="775" alt="screen shot 2015-12-02 at 12 46 02" src="https://cloud.githubusercontent.com/assets/277455/11530172/c5722940-98f2-11e5-8498-c9e484339b20.png">

The render method of ReduxRoutingContext has been updated to avoid rendering the original RoutingContext if 'location' is not defined, exactly as it's done in the original Router component from react-router
